### PR TITLE
implement list command, show project ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gh-prj"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 structopt = "0.3"
 octocrab = "0.15"
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 structopt = "0.3"
+octocrab = "0.15"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,7 @@
+use octocrab::models::Project;
+use std::io::Error;
 use std::process::{Command, Output};
+use std::str::{self};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -26,14 +29,33 @@ pub enum Cmd {
 pub fn exec_cmd(args: CommandLineArgs) {
     let CommandLineArgs { cmd } = args;
     match cmd {
-        List => list_prj(),
-        View => {}
+        Cmd::List { web } => list_prj(),
+        Cmd::View { web } => view_prj(),
     }
 }
 
 fn list_prj() {
     let result = gh(&["api", "/repos/{owner}/{repo}/projects"]);
-    println!("{:#?}", result);
+    let projects = extract_projects(result);
+    if projects.len() != 0 {
+        let project = &projects[0];
+        println!("{:#?}", project.number);
+    } else {
+        // TODO: display owner/repo
+        println!("This repository does not found any projects")
+    }
+}
+
+fn view_prj() {
+    // TODO
+    println!("Not implemented view command");
+}
+
+fn extract_projects(result: Output) -> Vec<Project> {
+    let stdout = str::from_utf8(&result.stdout).expect("Failed to covert str from API result");
+    let projects =
+        serde_json::from_reader(stdout.as_bytes()).expect("Failed to deserialize API result");
+    projects
 }
 
 fn gh(args: &[&str]) -> Output {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,44 @@
+use std::process::{Command, Output};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "prj")]
+pub struct CommandLineArgs {
+    #[structopt(subcommand)]
+    pub cmd: Cmd,
+}
+
+#[derive(StructOpt, Debug)]
+pub enum Cmd {
+    /// List Projects in this repository
+    List {
+        #[structopt(short = "w", long)]
+        web: bool,
+    },
+
+    /// Display the information about a Project
+    View {
+        #[structopt(short = "w", long)]
+        web: bool,
+    },
+}
+
+pub fn exec_cmd(args: CommandLineArgs) {
+    let CommandLineArgs { cmd } = args;
+    match cmd {
+        List => list_prj(),
+        View => {}
+    }
+}
+
+fn list_prj() {
+    let result = gh(&["api", "/repos/{owner}/{repo}/projects"]);
+    println!("{:#?}", result);
+}
+
+fn gh(args: &[&str]) -> Output {
+    Command::new("gh")
+        .args(args)
+        .output()
+        .expect("Failed to execute gh command")
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,4 @@
 use octocrab::models::Project;
-use std::io::Error;
 use std::process::{Command, Output};
 use std::str::{self};
 use structopt::StructOpt;
@@ -29,20 +28,22 @@ pub enum Cmd {
 pub fn exec_cmd(args: CommandLineArgs) {
     let CommandLineArgs { cmd } = args;
     match cmd {
-        Cmd::List { web } => list_prj(),
-        Cmd::View { web } => view_prj(),
+        Cmd::List { .. } => list_prj(),
+        Cmd::View { .. } => view_prj(),
     }
 }
 
 fn list_prj() {
     let result = gh(&["api", "/repos/{owner}/{repo}/projects"]);
     let projects = extract_projects(result);
-    if projects.len() != 0 {
-        let project = &projects[0];
-        println!("{:#?}", project.number);
-    } else {
+    if projects.is_empty() {
         // TODO: display owner/repo
-        println!("This repository does not found any projects")
+        println!("This repository does not found any projects");
+        return;
+    }
+
+    for prj in projects {
+        println!("{:#?}\n", prj.number);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+use structopt::StructOpt;
+mod cli;
+use cli::CommandLineArgs;
+
 fn main() {
-    println!("Hello, world!");
+    let args = CommandLineArgs::from_args();
+    cli::exec_cmd(args)
 }


### PR DESCRIPTION
#10 

- add structopt crate
- add list command interface
- add octocrab crate
- extract projects information from api result

projects apiを叩いてidを出力するところまで。
このPRではとりあえずproject id を表示するところまで。これさえあればpecoを使ってこんな感じでブラウザで開けるので、自分の用途としては使える

```
gh prj list | peco | xargs -I@ open https://github.com/MH4GF/gh-prj/projects/@
```